### PR TITLE
Fix: Stabilize database-dependent tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,12 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        implementation 'org.springframework.boot:spring-boot-starter-web'
+        testImplementation 'org.springframework.boot:spring-boot-starter-test'
+        testImplementation 'com.h2database:h2'
 
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+        compileOnly 'org.projectlombok:lombok'
+        annotationProcessor 'org.projectlombok:lombok'
 	implementation group: 'com.mysql', name: 'mysql-connector-j', version: '8.0.32'
 //	implementation 'mysql:mysql-connector-java:8.0.33'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/test/java/com/example/Roomy/RoomyApplicationTests.java
+++ b/src/test/java/com/example/Roomy/RoomyApplicationTests.java
@@ -2,8 +2,10 @@ package com.example.Roomy;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class RoomyApplicationTests {
 
 	@Test

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -1,0 +1,9 @@
+spring.datasource.url=jdbc:h2:mem:roomytest;MODE=MYSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.jpa.show-sql=false
+spring.jpa.properties.hibernate.format_sql=false
+spring.sql.init.mode=never


### PR DESCRIPTION
## Summary
- add the H2 database dependency for tests so they no longer require a local MySQL instance
- configure a dedicated test profile that points to the in-memory database
- load the test profile in RoomyApplicationTests to keep the Spring context bootstrapping self-contained

## Testing
- Unable to run tests locally (Gradle wrapper could not download the required distribution in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e88a5f3a3883329055a578eaca5387